### PR TITLE
Allow claiming rewards from earlier chapters

### DIFF
--- a/app/Http/Controllers/Api/CharacterJourneyController.php
+++ b/app/Http/Controllers/Api/CharacterJourneyController.php
@@ -108,28 +108,11 @@ class CharacterJourneyController extends Controller
 
         $chapterId = $request->input('chapter_id');
 
-        $wave = $request->input('wave');
-
         if (! is_numeric($chapterId) || (int) $chapterId <= 0) {
             return response()->json(ErrorService::errorCode(__METHOD__, 'JOURNEY:0001'), 422);
         }
-
-        if (! is_numeric($wave) || (int) $wave < 0) {
-            return response()->json(ErrorService::errorCode(__METHOD__, 'JOURNEY:0002'), 422);
-        }
-
-        // 取得獎勵id
-        $rewardId = $this->journeyService->getRewardIdByChapterAndWave($chapterId, $wave);
-
-        if (! $rewardId) {
-            return response()->json(ErrorService::errorCode(__METHOD__, 'JOURNEY:0003'), 422);
-        }
-
-        if (! $this->journeyService->canClaimReward($chapterId, $wave, $uid)) {
-            return response()->json(ErrorService::errorCode(__METHOD__, 'JOURNEY:0004'), 422);
-        }
         try {
-            $result = $this->journeyService->claimChapterReward($uid, $rewardId);
+            $result = $this->journeyService->claimChapterReward($uid, (int) $chapterId);
 
         } catch (\RuntimeException $exception) {
             $code = $exception->getMessage();
@@ -144,7 +127,6 @@ class CharacterJourneyController extends Controller
 
                 'uid' => $uid,
                 'chapter_id' => $chapterId,
-                'wave' => $wave,
                 'message' => $throwable->getMessage(),
 
             ]);

--- a/app/Service/UserJourneyService.php
+++ b/app/Service/UserJourneyService.php
@@ -142,10 +142,9 @@ class UserJourneyService
      *
      * @param int $uid 玩家 UID
      * @param int $chapterId 章節編號（允許 unique_id 或主鍵）
-     * @param int $wave 玩家當前波次
      * @return array
      */
-    public function claimChapterReward(int $uid, int $chapterId, int $wave): array
+    public function claimChapterReward(int $uid, int $chapterId): array
     {
         $journey = $this->findJourneyByIdentifier($chapterId);
 
@@ -153,22 +152,28 @@ class UserJourneyService
             throw new \RuntimeException('JourneyReward:0001');
         }
 
-        return DB::transaction(function () use ($uid, $journey, $wave) {
+        return DB::transaction(function () use ($uid, $journey) {
             $record = UserJourneyRecord::where('uid', $uid)->lockForUpdate()->first();
 
             if (! $record) {
                 throw new \RuntimeException('JourneyReward:0003');
             }
 
-            if ((int) $record->current_journey_id !== (int) $journey->unique_id) {
+            $playerChapterId = (int) $record->current_journey_id;
+            $targetChapterId = (int) $journey->unique_id;
+
+            if ($playerChapterId < $targetChapterId) {
                 throw new \RuntimeException('JourneyReward:0002');
             }
 
-            $availableWave = min((int) $record->current_wave, (int) max(0, $wave));
+            $availableWave = (int) $record->current_wave;
+            $isCurrentChapter = $playerChapterId === $targetChapterId;
 
             $rewardCandidates = GddbSurgameJourneyReward::query()
                 ->where('journey_id', $journey->id)
-                ->where('wave', '<=', $availableWave)
+                ->when($isCurrentChapter, function ($query) use ($availableWave) {
+                    $query->where('wave', '<=', $availableWave);
+                })
                 ->orderBy('wave')
                 ->get();
 
@@ -183,39 +188,71 @@ class UserJourneyService
                 ->get()
                 ->keyBy('reward_id');
 
-            $targetReward = null;
+            $claimableRewards = [];
 
             foreach ($rewardCandidates as $candidate) {
                 $claimed = $claimedMap->get($candidate->id);
 
                 if (! $claimed || (int) $claimed->is_received !== 1) {
-                    $targetReward = $candidate;
-                    break;
+                    $claimableRewards[] = $candidate;
                 }
             }
 
-            if (! $targetReward) {
+            if (empty($claimableRewards)) {
                 throw new \RuntimeException('JourneyReward:0004');
             }
 
-            $formattedRewards = $this->formatRewards($targetReward->rewards);
-            $deliveredList    = $this->grantRewardsToUser($uid, $formattedRewards, '冒險章節獎勵領取');
+            $aggregatedRewards = [];
+            $claimedWaves      = [];
 
-            UserJourneyRewardMap::updateOrCreate(
-                [
-                    'uid'       => $uid,
-                    'reward_id' => (int) $targetReward->id,
-                ],
-                [
-                    'is_received' => 1,
-                ]
-            );
+            foreach ($claimableRewards as $reward) {
+                $claimedWaves[] = (int) $reward->wave;
+
+                foreach ($this->formatRewards($reward->rewards) as $item) {
+                    $itemId = (int) ($item['item_id'] ?? 0);
+                    $amount = (int) ($item['amount'] ?? 0);
+
+                    if ($itemId <= 0 || $amount <= 0) {
+                        continue;
+                    }
+
+                    if (! isset($aggregatedRewards[$itemId])) {
+                        $aggregatedRewards[$itemId] = 0;
+                    }
+
+                    $aggregatedRewards[$itemId] += $amount;
+                }
+            }
+
+            $finalRewards = [];
+
+            foreach ($aggregatedRewards as $itemId => $amount) {
+                $finalRewards[] = [
+                    'item_id' => (int) $itemId,
+                    'amount'  => (int) $amount,
+                ];
+            }
+
+            $deliveredList = $this->grantRewardsToUser($uid, $finalRewards, '冒險章節獎勵領取');
+
+            foreach ($claimableRewards as $reward) {
+                UserJourneyRewardMap::updateOrCreate(
+                    [
+                        'uid'       => $uid,
+                        'reward_id' => (int) $reward->id,
+                    ],
+                    [
+                        'is_received' => 1,
+                    ]
+                );
+            }
+
+            sort($claimedWaves);
 
             return [
-                'reward_id'     => (int) $targetReward->id,
                 'chapter_id'    => (int) $journey->unique_id,
-                'wave'          => (int) $targetReward->wave,
-                'reward_status' => 2,
+                'reward_status' => 1,
+                'claimed_wave'  => array_values(array_unique($claimedWaves)),
                 'rewards'       => $deliveredList,
             ];
         });


### PR DESCRIPTION
## Summary
- allow players to claim rewards from any chapter they have already reached or surpassed
- skip wave gating when claiming an earlier chapter so all pending waves are awarded together

## Testing
- php -l app/Service/UserJourneyService.php

------
https://chatgpt.com/codex/tasks/task_e_68d65b415ba4832ea8fde860f1de6239